### PR TITLE
Add React client with Vite routing

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Smart Finance Dashboard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.jsx"></script>
+  </body>
+</html>

--- a/client/package.json
+++ b/client/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "client",
+  "version": "0.0.1",
+  "private": true,
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "vite": "^5.0.8",
+    "@vitejs/plugin-react": "^4.0.4",
+    "tailwindcss": "^3.4.4",
+    "postcss": "^8.4.16",
+    "autoprefixer": "^10.4.13"
+  }
+}

--- a/client/postcss.config.cjs
+++ b/client/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,0 +1,31 @@
+import { Routes, Route, Link } from 'react-router-dom';
+import Login from './pages/Login';
+import Register from './pages/Register';
+import Dashboard from './pages/Dashboard';
+import Transactions from './pages/Transactions';
+import Budget from './pages/Budget';
+
+function App() {
+  return (
+    <div className="min-h-screen bg-gray-100">
+      <nav className="bg-blue-600 text-white p-4 flex space-x-4">
+        <Link to="/login">Login</Link>
+        <Link to="/register">Register</Link>
+        <Link to="/dashboard">Dashboard</Link>
+        <Link to="/transactions">Transactions</Link>
+        <Link to="/budget">Budget</Link>
+      </nav>
+      <div className="p-4">
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
+          <Route path="/dashboard" element={<Dashboard />} />
+          <Route path="/transactions" element={<Transactions />} />
+          <Route path="/budget" element={<Budget />} />
+        </Routes>
+      </div>
+    </div>
+  );
+}
+
+export default App;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/client/src/pages/Budget.jsx
+++ b/client/src/pages/Budget.jsx
@@ -1,0 +1,9 @@
+function Budget() {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold">Budget</h1>
+      <p>Manage your budget categories and limits here.</p>
+    </div>
+  );
+}
+export default Budget;

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,0 +1,9 @@
+function Dashboard() {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold">Dashboard</h1>
+      <p>Welcome to your personal finance dashboard.</p>
+    </div>
+  );
+}
+export default Dashboard;

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,0 +1,13 @@
+function Login() {
+  return (
+    <div className="max-w-md mx-auto bg-white p-6 shadow">
+      <h1 className="text-2xl font-bold mb-4">Login</h1>
+      <form className="space-y-4">
+        <input className="w-full border p-2" placeholder="Email" />
+        <input className="w-full border p-2" placeholder="Password" type="password" />
+        <button type="submit" className="w-full bg-blue-600 text-white p-2">Sign In</button>
+      </form>
+    </div>
+  );
+}
+export default Login;

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -1,0 +1,13 @@
+function Register() {
+  return (
+    <div className="max-w-md mx-auto bg-white p-6 shadow">
+      <h1 className="text-2xl font-bold mb-4">Register</h1>
+      <form className="space-y-4">
+        <input className="w-full border p-2" placeholder="Email" />
+        <input className="w-full border p-2" placeholder="Password" type="password" />
+        <button type="submit" className="w-full bg-blue-600 text-white p-2">Sign Up</button>
+      </form>
+    </div>
+  );
+}
+export default Register;

--- a/client/src/pages/Transactions.jsx
+++ b/client/src/pages/Transactions.jsx
@@ -1,0 +1,9 @@
+function Transactions() {
+  return (
+    <div>
+      <h1 className="text-3xl font-bold">Transactions</h1>
+      <p>List of recent transactions will appear here.</p>
+    </div>
+  );
+}
+export default Transactions;

--- a/client/tailwind.config.cjs
+++ b/client/tailwind.config.cjs
@@ -1,0 +1,10 @@
+module.exports = {
+  content: [
+    './index.html',
+    './src/**/*.{js,jsx,ts,tsx}',
+  ],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};

--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173,
+  },
+});


### PR DESCRIPTION
## Summary
- scaffold `client` folder using Vite style structure
- add React Router DOM based routing for login, register, dashboard, transactions and budget pages
- configure Tailwind CSS with PostCSS and Vite

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_685ecd95995c832ba082e600742beb6b