### PR TITLE
Implement auth context and helper services

### DIFF
--- a/client/src/components/ProtectedRoute.jsx
+++ b/client/src/components/ProtectedRoute.jsx
@@ -1,0 +1,12 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+const ProtectedRoute = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+  return children;
+};
+
+export default ProtectedRoute;

--- a/client/src/context/AuthContext.jsx
+++ b/client/src/context/AuthContext.jsx
@@ -1,0 +1,36 @@
+import { createContext, useContext, useEffect, useState } from 'react';
+import * as authService from '../services/auth';
+
+const AuthContext = createContext();
+
+export const AuthProvider = ({ children }) => {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+
+  const login = async (credentials) => {
+    const data = await authService.login(credentials);
+    if (data.token) setUser({ token: data.token });
+    return data;
+  };
+
+  const logout = () => {
+    authService.logout();
+    setUser(null);
+  };
+
+  useEffect(() => {
+    const token = localStorage.getItem('token');
+    if (token) setUser({ token });
+    setLoading(false);
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ user, isAuthenticated: !!user, login, logout }}>
+      {!loading && children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => useContext(AuthContext);
+
+export default AuthContext;

--- a/client/src/services/auth.js
+++ b/client/src/services/auth.js
@@ -1,0 +1,19 @@
+import api from './api';
+
+export const login = async (credentials) => {
+  const res = await api.post('/auth/login', credentials);
+  const { token } = res.data;
+  if (token) {
+    localStorage.setItem('token', token);
+  }
+  return res.data;
+};
+
+export const register = async (data) => {
+  const res = await api.post('/auth/register', data);
+  return res.data;
+};
+
+export const logout = () => {
+  localStorage.removeItem('token');
+};

--- a/client/src/services/investment.js
+++ b/client/src/services/investment.js
@@ -1,0 +1,21 @@
+import api from './api';
+
+export const getInvestments = async () => {
+  const res = await api.get('/investments');
+  return res.data;
+};
+
+export const createInvestment = async (data) => {
+  const res = await api.post('/investments', data);
+  return res.data;
+};
+
+export const updateInvestment = async (id, data) => {
+  const res = await api.put(`/investments/${id}`, data);
+  return res.data;
+};
+
+export const deleteInvestment = async (id) => {
+  const res = await api.delete(`/investments/${id}`);
+  return res.data;
+};

--- a/client/src/utils/formatDate.js
+++ b/client/src/utils/formatDate.js
@@ -1,0 +1,5 @@
+export default function formatDate(input) {
+  const date = new Date(input);
+  if (Number.isNaN(date.getTime())) return '';
+  return date.toISOString().split('T')[0];
+}


### PR DESCRIPTION
## Summary
- add a simple date formatter utility
- implement `AuthContext` with login/logout helpers
- implement `ProtectedRoute` wrapper
- add API helpers for authentication and investments

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864e454eea0832bbcbb59357f836033