### PR TITLE
Make API base URL configurable

### DIFF
--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:5000/api

--- a/client/src/services/api.js
+++ b/client/src/services/api.js
@@ -3,7 +3,8 @@ import axios from 'axios';
 
 // Create the Axios instance
 const api = axios.create({
-  baseURL: 'http://localhost:5000/api', // ✅ change this when you deploy
+  // Read API URL from Vite environment with a localhost fallback
+  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:5000/api',
   headers: {
     'Content-Type': 'application/json',
   }


### PR DESCRIPTION
## Summary
- read API URL from `VITE_API_URL`
- add client `.env.example` with the variable

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864e5f34e38832bb7fbe6114b0dab93