### PR TITLE
Add input validation middleware

### DIFF
--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -1,0 +1,101 @@
+export const validateTransaction = (req, res, next) => {
+  const { type, amount } = req.body;
+  if (!type || !['income', 'expense'].includes(type)) {
+    return res.status(400).json({ error: 'Invalid or missing type' });
+  }
+  const amt = Number(amount);
+  if (isNaN(amt)) {
+    return res.status(400).json({ error: 'Invalid or missing amount' });
+  }
+  next();
+};
+
+export const validateTransactionUpdate = (req, res, next) => {
+  if (req.body.type && !['income', 'expense'].includes(req.body.type)) {
+    return res.status(400).json({ error: 'Invalid type' });
+  }
+  if (req.body.amount !== undefined && isNaN(Number(req.body.amount))) {
+    return res.status(400).json({ error: 'Invalid amount' });
+  }
+  next();
+};
+
+export const validateSaving = (req, res, next) => {
+  const { goal, targetAmount, contribution, dueDate } = req.body;
+  if (!goal || typeof goal !== 'string') {
+    return res.status(400).json({ error: 'Goal is required' });
+  }
+  if (isNaN(Number(targetAmount))) {
+    return res.status(400).json({ error: 'targetAmount must be a number' });
+  }
+  if (isNaN(Number(contribution))) {
+    return res.status(400).json({ error: 'contribution must be a number' });
+  }
+  if (!dueDate || isNaN(Date.parse(dueDate))) {
+    return res.status(400).json({ error: 'Valid dueDate required' });
+  }
+  next();
+};
+
+export const validateSavingContribution = (req, res, next) => {
+  if (isNaN(Number(req.body.amount))) {
+    return res.status(400).json({ error: 'amount must be a number' });
+  }
+  next();
+};
+
+export const validateSavingUpdate = (req, res, next) => {
+  const { goal, targetAmount, dueDate } = req.body;
+  if (goal !== undefined && typeof goal !== 'string') {
+    return res.status(400).json({ error: 'Invalid goal' });
+  }
+  if (targetAmount !== undefined && isNaN(Number(targetAmount))) {
+    return res.status(400).json({ error: 'Invalid targetAmount' });
+  }
+  if (dueDate !== undefined && isNaN(Date.parse(dueDate))) {
+    return res.status(400).json({ error: 'Invalid dueDate' });
+  }
+  next();
+};
+
+export const validateGoal = (req, res, next) => {
+  const { goalName, targetAmount, deadline } = req.body;
+  if (!goalName || typeof goalName !== 'string') {
+    return res.status(400).json({ error: 'goalName is required' });
+  }
+  if (isNaN(Number(targetAmount))) {
+    return res.status(400).json({ error: 'targetAmount must be a number' });
+  }
+  if (deadline && isNaN(Date.parse(deadline))) {
+    return res.status(400).json({ error: 'Invalid deadline' });
+  }
+  next();
+};
+
+export const validateInvestment = (req, res, next) => {
+  const { amount, assetType, date } = req.body;
+  if (isNaN(Number(amount))) {
+    return res.status(400).json({ error: 'amount must be a number' });
+  }
+  if (!assetType || typeof assetType !== 'string') {
+    return res.status(400).json({ error: 'assetType is required' });
+  }
+  if (date !== undefined && isNaN(Date.parse(date))) {
+    return res.status(400).json({ error: 'Invalid date' });
+  }
+  next();
+};
+
+export const validateInvestmentUpdate = (req, res, next) => {
+  const { amount, assetType, date } = req.body;
+  if (amount !== undefined && isNaN(Number(amount))) {
+    return res.status(400).json({ error: 'Invalid amount' });
+  }
+  if (assetType !== undefined && typeof assetType !== 'string') {
+    return res.status(400).json({ error: 'Invalid assetType' });
+  }
+  if (date !== undefined && isNaN(Date.parse(date))) {
+    return res.status(400).json({ error: 'Invalid date' });
+  }
+  next();
+};

--- a/routes/goalsRoutes.js
+++ b/routes/goalsRoutes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import Goal from '../models/Goal.js';
 import authMiddleware from '../middleware/authMiddleware.js';
+import { validateGoal } from '../middleware/validation.js';
 
 const router = express.Router();
 router.use(authMiddleware);
@@ -17,7 +18,7 @@ router.get('/', async (req, res) => {
 });
 
 // ✅ POST a new goal
-router.post('/', async (req, res) => {
+router.post('/', validateGoal, async (req, res) => {
   try {
     const { goalName, targetAmount, deadline } = req.body;
 

--- a/routes/investmentRoutes.js
+++ b/routes/investmentRoutes.js
@@ -1,12 +1,13 @@
 import express from 'express';
 import Investment from '../models/Investment.js';
 import authMiddleware from '../middleware/authMiddleware.js';
+import { validateInvestment, validateInvestmentUpdate } from '../middleware/validation.js';
 
 const router = express.Router();
 router.use(authMiddleware);
 
 // ✅ POST: Add investment
-router.post('/', async (req, res) => {
+router.post('/', validateInvestment, async (req, res) => {
   try {
     const { amount, assetType, institution, date } = req.body;
 
@@ -56,7 +57,7 @@ router.delete('/:id', async (req, res) => {
 });
 
 // ✅ PUT: Update an investment
-router.put('/:id', async (req, res) => {
+router.put('/:id', validateInvestmentUpdate, async (req, res) => {
   try {
     const updated = await Investment.findOneAndUpdate(
       { _id: req.params.id, userId: req.user._id },

--- a/routes/savingRoutes.js
+++ b/routes/savingRoutes.js
@@ -1,12 +1,13 @@
 import express from 'express';
 import Saving from '../models/Saving.js';
 import authMiddleware from '../middleware/authMiddleware.js';
+import { validateSaving, validateSavingContribution, validateSavingUpdate } from '../middleware/validation.js';
 
 const router = express.Router();
 router.use(authMiddleware);
 
 // ✅ POST: Create a new saving goal
-router.post('/', async (req, res) => {
+router.post('/', validateSaving, async (req, res) => {
   try {
     const { goal, targetAmount, contribution, dueDate } = req.body;
     const newSaving = new Saving({
@@ -25,7 +26,7 @@ router.post('/', async (req, res) => {
 });
 
 // ✅ POST: Add contribution to an existing saving
-router.post('/:id/contribute', async (req, res) => {
+router.post('/:id/contribute', validateSavingContribution, async (req, res) => {
   try {
     const { amount } = req.body;
     const saving = await Saving.findOne({ _id: req.params.id, userId: req.user.id });
@@ -68,7 +69,7 @@ router.delete('/:id', async (req, res) => {
 });
 
 // ✅ PUT: Update an existing saving goal
-router.put('/:id', async (req, res) => {
+router.put('/:id', validateSavingUpdate, async (req, res) => {
   try {
     const { goal, targetAmount, dueDate } = req.body;
 

--- a/routes/transactionRoutes.js
+++ b/routes/transactionRoutes.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import Transaction from '../models/Transaction.js';
-import authMiddleware from '../middleware/authMiddleware.js'; // ✅ Auth middleware
+import authMiddleware from '../middleware/authMiddleware.js';
+import { validateTransaction, validateTransactionUpdate } from '../middleware/validation.js';
 
 const router = express.Router();
 
@@ -19,7 +20,7 @@ router.get('/', async (req, res) => {
 });
 
 // ✅ POST a new transaction (auto-assigns userId from token)
-router.post('/', async (req, res) => {
+router.post('/', validateTransaction, async (req, res) => {
   try {
     const transaction = new Transaction({
       ...req.body,
@@ -53,7 +54,7 @@ router.delete('/:id', async (req, res) => {
 });
 
 // ✅ PUT (Update) a transaction owned by the logged-in user
-router.put('/:id', async (req, res) => {
+router.put('/:id', validateTransactionUpdate, async (req, res) => {
   try {
     const updated = await Transaction.findOneAndUpdate(
       { _id: req.params.id, userId: req.user.id },


### PR DESCRIPTION
## Summary
- add middleware for request validation
- apply validation to transaction, saving, goal and investment routes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864f379cb70832b8fb1e4b273a1c7c0