### PR TITLE
Add auth middleware to categorize endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,9 @@ Each goal has a `goalName`, `targetAmount`, `currentSaved` and an optional `dead
 
 ## Categorize Endpoint
 
-`POST /api/categorize` accepts a JSON body with an `expenseDescription` string.
-It returns a suggested category using OpenAI or keyword matching.
+`POST /api/categorize` (requires JWT auth) accepts a JSON body with an
+`expenseDescription` string. It returns a suggested category using OpenAI or
+keyword matching.
 
 ```
 {

--- a/server.js
+++ b/server.js
@@ -103,7 +103,7 @@ async function checkRecurringTransaction(userId, vendor, amount) {
   }
 }
 
-app.post('/api/categorize', async (req, res) => {
+app.post('/api/categorize', authMiddleware, async (req, res) => {
   const { expenseDescription } = req.body || {};
   if (!expenseDescription || typeof expenseDescription !== 'string') {
     return res.status(400).json({ error: 'expenseDescription required' });


### PR DESCRIPTION
## Summary
- require `authMiddleware` on the `/api/categorize` route
- document the authentication requirement for the categorize endpoint

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864f813ef40832b8544472f290d7038