### PR TITLE
Enable cookie-based auth

### DIFF
--- a/middleware/authMiddleware.js
+++ b/middleware/authMiddleware.js
@@ -3,12 +3,17 @@ import User from '../models/User.js'; // ✅ Make sure this import exists
 
 const authMiddleware = async (req, res, next) => {
   const authHeader = req.headers.authorization;
+  let token;
 
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return res.status(401).json({ error: 'Authorization token required' });
+  if (authHeader && authHeader.startsWith('Bearer ')) {
+    token = authHeader.split(' ')[1];
+  } else if (req.cookies && req.cookies.token) {
+    token = req.cookies.token;
   }
 
-  const token = authHeader.split(' ')[1];
+  if (!token) {
+    return res.status(401).json({ error: 'Authorization token required' });
+  }
 
   try {
     const decoded = jwt.verify(token, process.env.JWT_SECRET);

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "jsonwebtoken": "^9.0.2",
     "mongoose": "^7.5.0",
     "multer": "^1.4.4",
-    "openai": "^4.0.0"
+    "openai": "^4.0.0",
+    "cookie-parser": "^1.4.6"
   }
 }

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ import cors from 'cors';
 import OpenAI from 'openai';
 import multer from 'multer';
 import fs from 'fs';
+import cookieParser from 'cookie-parser';
 
 import Income from './models/Income.js';
 import Expense from './models/Expense.js';
@@ -28,6 +29,7 @@ const openai = new OpenAI({ apiKey: process.env.OPENAI_API_KEY });
 
 const app = express();
 app.use(express.json());
+app.use(cookieParser());
 app.use(cors({ origin: process.env.CLIENT_URL, credentials: true }));
 
 app.use('/api/transactions', transactionRoutes);


### PR DESCRIPTION
## Summary
- set up cookie-parser and CORS credentials
- store JWT token in a cookie after register and login
- check cookies inside auth middleware

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864f8d3ba84832bbe1ccf47578ad23c