### PR TITLE
Add loading and error messages

### DIFF
--- a/client/src/pages/Expenses.jsx
+++ b/client/src/pages/Expenses.jsx
@@ -6,6 +6,7 @@ const Expenses = () => {
   const [filterMonth, setFilterMonth] = useState('');
   const [filterCategory, setFilterCategory] = useState('');
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   const categories = [
     'Food',
@@ -18,6 +19,8 @@ const Expenses = () => {
   ];
 
   const fetchExpenses = async () => {
+    setLoading(true);
+    setError('');
     try {
       const res = await api.get('/transactions');
       const filtered = res.data.filter(
@@ -26,6 +29,7 @@ const Expenses = () => {
       setExpenses(filtered);
     } catch (err) {
       console.error('Failed to load expenses:', err.response?.data || err.message);
+      setError(err.response?.data?.message || err.message);
     } finally {
       setLoading(false);
     }
@@ -44,6 +48,7 @@ const Expenses = () => {
   return (
     <div className="max-w-2xl mx-auto bg-white p-6 rounded shadow">
       <h1 className="text-2xl font-bold mb-4">Expenses</h1>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
 
       <div className="flex flex-wrap gap-4 mb-6">
         <div>

--- a/client/src/pages/Income.jsx
+++ b/client/src/pages/Income.jsx
@@ -3,6 +3,8 @@ import api from '../services/api';
 
 const Income = () => {
   const [incomes, setIncomes] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
   const [formData, setFormData] = useState({
     type: 'income',
     amount: '',
@@ -17,12 +19,17 @@ const Income = () => {
   const categories = ['Salary', 'Freelance', 'Business', 'Investment', 'Gift', 'Other'];
 
   const fetchIncomes = async () => {
+    setLoading(true);
+    setError('');
     try {
       const res = await api.get('/transactions');
       const onlyIncomes = res.data.filter((txn) => txn.type === 'income');
       setIncomes(onlyIncomes);
     } catch (err) {
       console.error('Error fetching incomes:', err.response?.data || err.message);
+      setError(err.response?.data?.message || err.message);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -49,6 +56,7 @@ const Income = () => {
       fetchIncomes();
     } catch (err) {
       console.error('Error saving income:', err.response?.data || err.message);
+      setError(err.response?.data?.message || err.message);
     }
   };
 
@@ -59,6 +67,7 @@ const Income = () => {
       fetchIncomes();
     } catch (err) {
       console.error('Error deleting income:', err.response?.data || err.message);
+      setError(err.response?.data?.message || err.message);
     }
   };
 
@@ -77,6 +86,7 @@ const Income = () => {
   return (
     <div className="max-w-2xl mx-auto bg-white p-6 rounded shadow">
       <h1 className="text-2xl font-bold mb-4">Income Tracker</h1>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
 
       {/* Income Form */}
       <form onSubmit={handleSubmit} className="space-y-4">
@@ -170,7 +180,9 @@ const Income = () => {
           </div>
         </div>
 
-        {filtered.length === 0 ? (
+        {loading ? (
+          <p className="text-gray-500">Loading incomes...</p>
+        ) : filtered.length === 0 ? (
           <p className="text-gray-500">No income added yet.</p>
         ) : (
           <ul className="space-y-3">

--- a/client/src/pages/Transactions.jsx
+++ b/client/src/pages/Transactions.jsx
@@ -15,6 +15,8 @@ const Transactions = () => {
   const [editId, setEditId] = useState(null);
   const [filterMonth, setFilterMonth] = useState('');
   const [filterCategory, setFilterCategory] = useState('');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
 
   const incomeCategories = ['Salary', 'Freelance', 'Bonus', 'Gift', 'Other'];
   const expenseCategories = ['Food', 'Rent', 'Utilities', 'Entertainment', 'Health', 'Transport', 'Other'];
@@ -29,11 +31,16 @@ const Transactions = () => {
   };
 
   const fetchTransactions = async () => {
+    setLoading(true);
+    setError('');
     try {
       const response = await api.get('/transactions');
       setTransactions(response.data);
     } catch (error) {
       console.error('Error fetching transactions:', error.response?.data || error.message);
+      setError(error.response?.data?.message || error.message);
+    } finally {
+      setLoading(false);
     }
   };
 
@@ -44,6 +51,7 @@ const Transactions = () => {
       fetchTransactions();
     } catch (error) {
       console.error('Error deleting transaction:', error.response?.data || error.message);
+      setError(error.response?.data?.message || error.message);
     }
   };
 
@@ -90,6 +98,7 @@ const Transactions = () => {
       fetchTransactions();
     } catch (err) {
       console.error('Error submitting transaction:', err.response?.data || err.message);
+      setError(err.response?.data?.message || err.message);
     }
   };
 
@@ -102,6 +111,7 @@ const Transactions = () => {
       <h1 className="text-2xl font-bold mb-4">
         {isEditing ? 'Edit Transaction' : 'Add Transaction'}
       </h1>
+      {error && <p className="text-red-500 mb-4">{error}</p>}
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
@@ -216,7 +226,9 @@ const Transactions = () => {
           </div>
         </div>
 
-        {transactions.length === 0 ? (
+        {loading ? (
+          <p className="text-gray-500">Loading transactions...</p>
+        ) : transactions.length === 0 ? (
           <p className="text-gray-500">No transactions yet.</p>
         ) : (
           <ul className="space-y-3">


### PR DESCRIPTION
## Summary
- handle fetch errors in Income, Expenses and Transactions pages
- add loading indicators to Income and Transactions lists

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6864f9a66ba0832ba938e65fced0ee72