### PR TITLE
Introduce reusable form inputs

### DIFF
--- a/client/src/components/forms/CategorySelect.jsx
+++ b/client/src/components/forms/CategorySelect.jsx
@@ -1,0 +1,46 @@
+import PropTypes from 'prop-types';
+
+const CategorySelect = ({
+  label,
+  name,
+  value,
+  onChange,
+  options = [],
+  required = false,
+  placeholder = '-- Select Category --',
+  className = '',
+  ...props
+}) => (
+  <div>
+    {label && <label className="block mb-1 font-medium" htmlFor={name}>{label}</label>}
+    <select
+      id={name}
+      name={name}
+      value={value}
+      onChange={onChange}
+      required={required}
+      className={`w-full border p-2 rounded ${className}`.trim()}
+      {...props}
+    >
+      <option value="">{placeholder}</option>
+      {options.map((opt) => (
+        <option key={opt} value={opt}>
+          {opt}
+        </option>
+      ))}
+    </select>
+  </div>
+);
+
+CategorySelect.propTypes = {
+  label: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  onChange: PropTypes.func.isRequired,
+  options: PropTypes.arrayOf(PropTypes.string),
+  required: PropTypes.bool,
+  placeholder: PropTypes.string,
+  className: PropTypes.string,
+};
+
+export default CategorySelect;

--- a/client/src/components/forms/DateInput.jsx
+++ b/client/src/components/forms/DateInput.jsx
@@ -1,0 +1,38 @@
+import PropTypes from 'prop-types';
+
+const DateInput = ({
+  label,
+  name,
+  value,
+  onChange,
+  type = 'date',
+  required = false,
+  className = '',
+  ...props
+}) => (
+  <div>
+    {label && <label className="block mb-1 font-medium" htmlFor={name}>{label}</label>}
+    <input
+      type={type}
+      id={name}
+      name={name}
+      value={value}
+      onChange={onChange}
+      required={required}
+      className={`w-full border p-2 rounded ${className}`.trim()}
+      {...props}
+    />
+  </div>
+);
+
+DateInput.propTypes = {
+  label: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  onChange: PropTypes.func.isRequired,
+  type: PropTypes.string,
+  required: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export default DateInput;

--- a/client/src/components/forms/NumberInput.jsx
+++ b/client/src/components/forms/NumberInput.jsx
@@ -1,0 +1,30 @@
+import PropTypes from 'prop-types';
+
+const NumberInput = ({ label, name, value, onChange, placeholder = '', required = false, className = '', ...props }) => (
+  <div>
+    {label && <label className="block mb-1 font-medium" htmlFor={name}>{label}</label>}
+    <input
+      type="number"
+      id={name}
+      name={name}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      required={required}
+      className={`w-full border p-2 rounded ${className}`.trim()}
+      {...props}
+    />
+  </div>
+);
+
+NumberInput.propTypes = {
+  label: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  onChange: PropTypes.func.isRequired,
+  placeholder: PropTypes.string,
+  required: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export default NumberInput;

--- a/client/src/components/forms/TextInput.jsx
+++ b/client/src/components/forms/TextInput.jsx
@@ -1,0 +1,41 @@
+import PropTypes from 'prop-types';
+
+const TextInput = ({
+  label,
+  name,
+  value,
+  onChange,
+  type = 'text',
+  placeholder = '',
+  required = false,
+  className = '',
+  ...props
+}) => (
+  <div>
+    {label && <label className="block mb-1 font-medium" htmlFor={name}>{label}</label>}
+    <input
+      type={type}
+      id={name}
+      name={name}
+      value={value}
+      onChange={onChange}
+      placeholder={placeholder}
+      required={required}
+      className={`w-full border p-2 rounded ${className}`.trim()}
+      {...props}
+    />
+  </div>
+);
+
+TextInput.propTypes = {
+  label: PropTypes.string,
+  name: PropTypes.string.isRequired,
+  value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]).isRequired,
+  onChange: PropTypes.func.isRequired,
+  type: PropTypes.string,
+  placeholder: PropTypes.string,
+  required: PropTypes.bool,
+  className: PropTypes.string,
+};
+
+export default TextInput;

--- a/client/src/components/forms/index.js
+++ b/client/src/components/forms/index.js
@@ -1,0 +1,4 @@
+export { default as TextInput } from './TextInput.jsx';
+export { default as NumberInput } from './NumberInput.jsx';
+export { default as DateInput } from './DateInput.jsx';
+export { default as CategorySelect } from './CategorySelect.jsx';

--- a/client/src/pages/Budget.jsx
+++ b/client/src/pages/Budget.jsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react';
 import api from '../services/api';
+import {
+  TextInput,
+  NumberInput,
+  DateInput,
+  CategorySelect,
+} from '../components/forms';
 
 const categories = ['Food', 'Rent', 'Utilities', 'Entertainment', 'Health', 'Transport', 'Other'];
 
@@ -69,47 +75,31 @@ const Budget = () => {
       <h1 className="text-2xl font-bold mb-4">Monthly Budgets</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="block mb-1 font-medium">Category</label>
-          <select
-            name="category"
-            value={formData.category}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          >
-            <option value="">-- Select Category --</option>
-            {categories.map((cat) => (
-              <option key={cat} value={cat}>
-                {cat}
-              </option>
-            ))}
-          </select>
-        </div>
+        <CategorySelect
+          label="Category"
+          name="category"
+          value={formData.category}
+          onChange={handleChange}
+          options={categories}
+          required
+        />
 
-        <div>
-          <label className="block mb-1 font-medium">Amount (€)</label>
-          <input
-            type="number"
-            name="amount"
-            value={formData.amount}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <NumberInput
+          label="Amount (€)"
+          name="amount"
+          value={formData.amount}
+          onChange={handleChange}
+          required
+        />
 
-        <div>
-          <label className="block mb-1 font-medium">Month</label>
-          <input
-            type="month"
-            name="month"
-            value={formData.month}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <DateInput
+          label="Month"
+          type="month"
+          name="month"
+          value={formData.month}
+          onChange={handleChange}
+          required
+        />
 
         <div className="flex gap-2">
           <button
@@ -138,12 +128,12 @@ const Budget = () => {
         <h2 className="text-xl font-semibold mb-3">Budgets</h2>
 
         <div className="mb-4">
-          <label className="block text-sm font-medium mb-1">Filter by Month</label>
-          <input
+          <DateInput
+            label="Filter by Month"
             type="month"
+            name="filterMonth"
             value={filterMonth}
             onChange={(e) => setFilterMonth(e.target.value)}
-            className="border p-2 rounded"
           />
         </div>
 

--- a/client/src/pages/Expenses.jsx
+++ b/client/src/pages/Expenses.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import api from '../services/api';
+import { CategorySelect } from '../components/forms';
 
 const Expenses = () => {
   const [expenses, setExpenses] = useState([]);
@@ -61,21 +62,14 @@ const Expenses = () => {
           />
         </div>
 
-        <div>
-          <label className="block text-sm font-medium mb-1">Filter by Category</label>
-          <select
-            value={filterCategory}
-            onChange={(e) => setFilterCategory(e.target.value)}
-            className="border p-2 rounded"
-          >
-            <option value="">All</option>
-            {categories.map((cat) => (
-              <option key={cat} value={cat}>
-                {cat}
-              </option>
-            ))}
-          </select>
-        </div>
+        <CategorySelect
+          label="Filter by Category"
+          name="filterCategory"
+          value={filterCategory}
+          onChange={(e) => setFilterCategory(e.target.value)}
+          options={categories}
+          placeholder="All"
+        />
       </div>
 
       {loading ? (

--- a/client/src/pages/Goals.jsx
+++ b/client/src/pages/Goals.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import api from '../services/api';
+import { TextInput, NumberInput, DateInput } from '../components/forms';
 
 const Goals = () => {
   const [formData, setFormData] = useState({
@@ -53,38 +54,26 @@ const Goals = () => {
     <div className="max-w-xl mx-auto p-6 bg-white rounded shadow">
       <h1 className="text-2xl font-bold mb-4">Set a Financial Goal</h1>
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="block mb-1 font-medium">Goal Name</label>
-          <input
-            type="text"
-            name="goalName"
-            value={formData.goalName}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-            required
-          />
-        </div>
-        <div>
-          <label className="block mb-1 font-medium">Target Amount</label>
-          <input
-            type="number"
-            name="targetAmount"
-            value={formData.targetAmount}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-            required
-          />
-        </div>
-        <div>
-          <label className="block mb-1 font-medium">Deadline</label>
-          <input
-            type="date"
-            name="deadline"
-            value={formData.deadline}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <TextInput
+          label="Goal Name"
+          name="goalName"
+          value={formData.goalName}
+          onChange={handleChange}
+          required
+        />
+        <NumberInput
+          label="Target Amount"
+          name="targetAmount"
+          value={formData.targetAmount}
+          onChange={handleChange}
+          required
+        />
+        <DateInput
+          label="Deadline"
+          name="deadline"
+          value={formData.deadline}
+          onChange={handleChange}
+        />
         <button
           type="submit"
           className="bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700"

--- a/client/src/pages/Income.jsx
+++ b/client/src/pages/Income.jsx
@@ -1,5 +1,11 @@
 import { useState, useEffect } from 'react';
 import api from '../services/api';
+import {
+  TextInput,
+  NumberInput,
+  DateInput,
+  CategorySelect,
+} from '../components/forms';
 
 const Income = () => {
   const [incomes, setIncomes] = useState([]);
@@ -90,57 +96,38 @@ const Income = () => {
 
       {/* Income Form */}
       <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <label className="block mb-1 font-medium">Amount (€)</label>
-          <input
-            type="number"
-            name="amount"
-            value={formData.amount}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <NumberInput
+          label="Amount (€)"
+          name="amount"
+          value={formData.amount}
+          onChange={handleChange}
+          required
+        />
 
-        <div>
-          <label className="block mb-1 font-medium">Category</label>
-          <select
-            name="category"
-            value={formData.category}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          >
-            <option value="">-- Select Category --</option>
-            {categories.map((cat) => (
-              <option key={cat} value={cat}>{cat}</option>
-            ))}
-          </select>
-        </div>
+        <CategorySelect
+          label="Category"
+          name="category"
+          value={formData.category}
+          onChange={handleChange}
+          options={categories}
+          required
+        />
 
-        <div>
-          <label className="block mb-1 font-medium">Date</label>
-          <input
-            type="date"
-            name="date"
-            value={formData.date}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <DateInput
+          label="Date"
+          name="date"
+          value={formData.date}
+          onChange={handleChange}
+          required
+        />
 
-        <div>
-          <label className="block mb-1 font-medium">Description</label>
-          <input
-            type="text"
-            name="description"
-            value={formData.description}
-            onChange={handleChange}
-            placeholder="e.g. Bonus or payment note"
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <TextInput
+          label="Description"
+          name="description"
+          value={formData.description}
+          onChange={handleChange}
+          placeholder="e.g. Bonus or payment note"
+        />
 
         <button
           type="submit"

--- a/client/src/pages/Investments.jsx
+++ b/client/src/pages/Investments.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react';
 import api from '../services/api';
+import { TextInput, NumberInput, DateInput } from '../components/forms';
 
 const Investments = () => {
   const [investments, setInvestments] = useState([]);
@@ -72,10 +73,33 @@ const Investments = () => {
       <h2 className="text-2xl font-bold mb-4">{isEditing ? 'Edit' : 'Add'} Investment</h2>
 
       <form onSubmit={handleSubmit} className="space-y-4">
-        <input name="name" value={formData.name} onChange={handleChange} placeholder="Investment name" className="w-full border p-2 rounded" required />
-        <input name="amount" type="number" value={formData.amount} onChange={handleChange} placeholder="Amount" className="w-full border p-2 rounded" required />
-        <input name="type" value={formData.type} onChange={handleChange} placeholder="Type (e.g. ETF, Stock)" className="w-full border p-2 rounded" required />
-        <input name="date" type="date" value={formData.date} onChange={handleChange} className="w-full border p-2 rounded" required />
+        <TextInput
+          name="name"
+          value={formData.name}
+          onChange={handleChange}
+          placeholder="Investment name"
+          required
+        />
+        <NumberInput
+          name="amount"
+          value={formData.amount}
+          onChange={handleChange}
+          placeholder="Amount"
+          required
+        />
+        <TextInput
+          name="type"
+          value={formData.type}
+          onChange={handleChange}
+          placeholder="Type (e.g. ETF, Stock)"
+          required
+        />
+        <DateInput
+          name="date"
+          value={formData.date}
+          onChange={handleChange}
+          required
+        />
 
         <div className="flex gap-3">
           <button type="submit" className="bg-blue-600 text-white px-4 py-2 rounded">

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import api from '../services/api';
+import { TextInput } from '../components/forms';
 
 const Login = () => {
   const navigate = useNavigate();
@@ -41,23 +42,23 @@ const Login = () => {
 
         {error && <p className="text-red-500 text-sm mb-4">{error}</p>}
 
-        <input
+        <TextInput
           type="email"
           name="email"
           placeholder="Email"
           value={formData.email}
           onChange={handleChange}
-          className="mb-4 p-2 border w-full rounded"
+          className="mb-4"
           required
         />
 
-        <input
+        <TextInput
           type="password"
           name="password"
           placeholder="Password"
           value={formData.password}
           onChange={handleChange}
-          className="mb-4 p-2 border w-full rounded"
+          className="mb-4"
           required
         />
 

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -2,6 +2,7 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import axios from '../services/api'; // Make sure this points to your axios setup
+import { TextInput } from '../components/forms';
 
 const Register = () => {
   const [email, setEmail] = useState('');
@@ -29,27 +30,25 @@ const Register = () => {
 
         {error && <p className="text-red-500 mb-2">{error}</p>}
 
-        <label className="block mb-2">
-          <span>Email</span>
-          <input
-            type="email"
-            className="w-full mt-1 p-2 border rounded"
-            value={email}
-            onChange={(e) => setEmail(e.target.value)}
-            required
-          />
-        </label>
+        <TextInput
+          type="email"
+          name="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          className="mb-2"
+          required
+        />
 
-        <label className="block mb-4">
-          <span>Password</span>
-          <input
-            type="password"
-            className="w-full mt-1 p-2 border rounded"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            required
-          />
-        </label>
+        <TextInput
+          type="password"
+          name="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="mb-4"
+          required
+        />
 
         <button
           type="submit"

--- a/client/src/pages/Savings.jsx
+++ b/client/src/pages/Savings.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import api from '../services/api';
+import { TextInput, NumberInput, DateInput } from '../components/forms';
 import {
   PieChart,
   Pie,
@@ -105,55 +106,43 @@ const Savings = ({ onChange }) => {
       <h1 className="text-2xl font-bold mb-4">Savings Goals</h1>
 
       <form onSubmit={handleSubmit} className="space-y-4 mb-6">
-        <div>
-          <label className="block mb-1 font-medium">Goal Name</label>
-          <input
-            type="text"
-            name="goal"
-            value={formData.goal}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <TextInput
+          label="Goal Name"
+          name="goal"
+          value={formData.goal}
+          onChange={handleChange}
+          required
+        />
 
         <div className="grid grid-cols-2 gap-4">
           <div>
-            <label className="block mb-1 font-medium">Target Amount (€)</label>
-            <input
-              type="number"
+            <NumberInput
+              label="Target Amount (€)"
               name="targetAmount"
               value={formData.targetAmount}
               onChange={handleChange}
               required
-              className="w-full border p-2 rounded"
             />
           </div>
 
           <div>
-            <label className="block mb-1 font-medium">Contribution (€)</label>
-            <input
-              type="number"
+            <NumberInput
+              label="Contribution (€)"
               name="contribution"
               value={formData.contribution}
               onChange={handleChange}
-              className="w-full border p-2 rounded"
               disabled={formData.editingId !== null}
             />
           </div>
         </div>
 
-        <div>
-          <label className="block mb-1 font-medium">Due Date</label>
-          <input
-            type="date"
-            name="dueDate"
-            value={formData.dueDate}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <DateInput
+          label="Due Date"
+          name="dueDate"
+          value={formData.dueDate}
+          onChange={handleChange}
+          required
+        />
 
         <button
           type="submit"

--- a/client/src/pages/Transactions.jsx
+++ b/client/src/pages/Transactions.jsx
@@ -1,5 +1,11 @@
 import { useState, useEffect } from 'react';
 import api from '../services/api';
+import {
+  TextInput,
+  NumberInput,
+  DateInput,
+  CategorySelect,
+} from '../components/forms';
 
 const Transactions = () => {
   const [formData, setFormData] = useState({
@@ -127,56 +133,37 @@ const Transactions = () => {
           </select>
         </div>
 
-        <div>
-          <label className="block mb-1 font-medium">Amount (€)</label>
-          <input
-            type="number"
-            name="amount"
-            value={formData.amount}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <NumberInput
+          label="Amount (€)"
+          name="amount"
+          value={formData.amount}
+          onChange={handleChange}
+          required
+        />
 
-        <div>
-          <label className="block mb-1 font-medium">Category</label>
-          <select
-            name="category"
-            value={formData.category}
-            onChange={handleChange}
-            className="w-full border p-2 rounded"
-          >
-            <option value="">-- Select Category --</option>
-            {dynamicCategories.map((cat) => (
-              <option key={cat} value={cat}>{cat}</option>
-            ))}
-          </select>
-        </div>
+        <CategorySelect
+          label="Category"
+          name="category"
+          value={formData.category}
+          onChange={handleChange}
+          options={dynamicCategories}
+        />
 
-        <div>
-          <label className="block mb-1 font-medium">Date</label>
-          <input
-            type="date"
-            name="date"
-            value={formData.date}
-            onChange={handleChange}
-            required
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <DateInput
+          label="Date"
+          name="date"
+          value={formData.date}
+          onChange={handleChange}
+          required
+        />
 
-        <div>
-          <label className="block mb-1 font-medium">Description</label>
-          <input
-            type="text"
-            name="description"
-            value={formData.description}
-            onChange={handleChange}
-            placeholder="e.g. Netflix, Aldi"
-            className="w-full border p-2 rounded"
-          />
-        </div>
+        <TextInput
+          label="Description"
+          name="description"
+          value={formData.description}
+          onChange={handleChange}
+          placeholder="e.g. Netflix, Aldi"
+        />
 
         <div className="flex gap-3">
           <button


### PR DESCRIPTION
## Summary
- create reusable form components (TextInput, NumberInput, DateInput, CategorySelect)
- refactor forms in pages to use new components

## Testing
- `npm --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650241c314832ba4612c4ba90aa16e