### PR TITLE
Add chart widgets

### DIFF
--- a/client/src/components/charts/BarChartWidget.jsx
+++ b/client/src/components/charts/BarChartWidget.jsx
@@ -1,0 +1,18 @@
+import { ResponsiveContainer, BarChart, CartesianGrid, XAxis, YAxis, Tooltip, Legend, Bar } from 'recharts';
+
+const BarChartWidget = ({ data, xKey = 'name', bars = [], height = 250 }) => (
+  <ResponsiveContainer width="100%" height={height}>
+    <BarChart data={data}>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey={xKey} />
+      <YAxis />
+      <Tooltip />
+      <Legend />
+      {bars.map(({ dataKey, fill }, idx) => (
+        <Bar key={dataKey || idx} dataKey={dataKey} fill={fill} />
+      ))}
+    </BarChart>
+  </ResponsiveContainer>
+);
+
+export default BarChartWidget;

--- a/client/src/components/charts/LineChartWidget.jsx
+++ b/client/src/components/charts/LineChartWidget.jsx
@@ -1,0 +1,16 @@
+import { ResponsiveContainer, LineChart, CartesianGrid, XAxis, YAxis, Tooltip, Legend, Line } from 'recharts';
+
+const LineChartWidget = ({ data, xKey = 'date', lineKey = 'value', color = '#8884d8', height = 250 }) => (
+  <ResponsiveContainer width="100%" height={height}>
+    <LineChart data={data}>
+      <CartesianGrid strokeDasharray="3 3" />
+      <XAxis dataKey={xKey} />
+      <YAxis />
+      <Tooltip />
+      <Legend />
+      <Line type="monotone" dataKey={lineKey} stroke={color} strokeWidth={2} />
+    </LineChart>
+  </ResponsiveContainer>
+);
+
+export default LineChartWidget;

--- a/client/src/components/charts/PieChartWidget.jsx
+++ b/client/src/components/charts/PieChartWidget.jsx
@@ -1,0 +1,24 @@
+import { ResponsiveContainer, PieChart, Pie, Cell, Tooltip } from 'recharts';
+
+const PieChartWidget = ({ data, dataKey = 'value', nameKey = 'name', colors = [], outerRadius = 80, height = 250 }) => (
+  <ResponsiveContainer width="100%" height={height}>
+    <PieChart>
+      <Pie
+        data={data}
+        dataKey={dataKey}
+        nameKey={nameKey}
+        cx="50%"
+        cy="50%"
+        outerRadius={outerRadius}
+        label
+      >
+        {data.map((_, index) => (
+          <Cell key={index} fill={colors[index % colors.length]} />
+        ))}
+      </Pie>
+      <Tooltip />
+    </PieChart>
+  </ResponsiveContainer>
+);
+
+export default PieChartWidget;

--- a/client/src/components/charts/index.js
+++ b/client/src/components/charts/index.js
@@ -1,0 +1,3 @@
+export { default as BarChartWidget } from './BarChartWidget.jsx';
+export { default as PieChartWidget } from './PieChartWidget.jsx';
+export { default as LineChartWidget } from './LineChartWidget.jsx';

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,20 +1,10 @@
 import { useEffect, useState } from 'react';
 import api from '../services/api';
 import {
-  BarChart,
-  Bar,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip,
-  PieChart,
-  Pie,
-  Cell,
-  ResponsiveContainer,
-  Legend,
-  LineChart,
-  Line,
-} from 'recharts';
+  BarChartWidget,
+  PieChartWidget,
+  LineChartWidget,
+} from '../components/charts';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7f7f', '#a1e3a1', '#ffd700', '#a1cfff'];
 
@@ -129,75 +119,34 @@ const Dashboard = () => {
           <div className="grid grid-cols-1 md:grid-cols-2 gap-6 mb-8">
             <div className="bg-gray-100 p-4 rounded">
               <h2 className="text-xl font-semibold mb-3">Income vs Expenses</h2>
-              <ResponsiveContainer width="100%" height={250}>
-                <BarChart data={[{ name: 'Totals', income: incomeTotal, expenses: expenseTotal }]}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="name" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Bar dataKey="income" fill="#82ca9d" />
-                  <Bar dataKey="expenses" fill="#ff7f7f" />
-                </BarChart>
-              </ResponsiveContainer>
+              <BarChartWidget
+                data={[{ name: 'Totals', income: incomeTotal, expenses: expenseTotal }]}
+                xKey="name"
+                bars={[
+                  { dataKey: 'income', fill: '#82ca9d' },
+                  { dataKey: 'expenses', fill: '#ff7f7f' },
+                ]}
+              />
             </div>
 
             <div className="bg-gray-100 p-4 rounded">
               <h2 className="text-xl font-semibold mb-3">Expenses by Category</h2>
-              <ResponsiveContainer width="100%" height={250}>
-                <PieChart>
-                  <Pie
-                    data={pieData}
-                    dataKey="value"
-                    nameKey="name"
-                    cx="50%"
-                    cy="50%"
-                    outerRadius={80}
-                    label
-                  >
-                    {pieData.map((_, index) => (
-                      <Cell key={index} fill={COLORS[index % COLORS.length]} />
-                    ))}
-                  </Pie>
-                  <Tooltip />
-                </PieChart>
-              </ResponsiveContainer>
+              <PieChartWidget data={pieData} colors={COLORS} outerRadius={80} />
             </div>
 
             <div className="bg-gray-100 p-4 rounded">
               <h2 className="text-xl font-semibold mb-3">Savings by Goal</h2>
-              <ResponsiveContainer width="100%" height={250}>
-                <PieChart>
-                  <Pie
-                    data={savingsPieData}
-                    dataKey="value"
-                    nameKey="name"
-                    cx="50%"
-                    cy="50%"
-                    outerRadius={80}
-                    label
-                  >
-                    {savingsPieData.map((_, index) => (
-                      <Cell key={index} fill={COLORS[index % COLORS.length]} />
-                    ))}
-                  </Pie>
-                  <Tooltip />
-                </PieChart>
-              </ResponsiveContainer>
+              <PieChartWidget data={savingsPieData} colors={COLORS} outerRadius={80} />
             </div>
 
             <div className="bg-gray-100 p-4 rounded">
               <h2 className="text-xl font-semibold mb-3">Balance Over Time</h2>
-              <ResponsiveContainer width="100%" height={250}>
-                <LineChart data={balanceOverTime}>
-                  <CartesianGrid strokeDasharray="3 3" />
-                  <XAxis dataKey="date" />
-                  <YAxis />
-                  <Tooltip />
-                  <Legend />
-                  <Line type="monotone" dataKey="balance" stroke="#8884d8" strokeWidth={2} />
-                </LineChart>
-              </ResponsiveContainer>
+              <LineChartWidget
+                data={balanceOverTime}
+                xKey="date"
+                lineKey="balance"
+                color="#8884d8"
+              />
             </div>
           </div>
 

--- a/client/src/pages/Savings.jsx
+++ b/client/src/pages/Savings.jsx
@@ -1,13 +1,7 @@
 import { useState, useEffect } from 'react';
 import api from '../services/api';
 import { TextInput, NumberInput, DateInput } from '../components/forms';
-import {
-  PieChart,
-  Pie,
-  Cell,
-  Tooltip,
-  ResponsiveContainer,
-} from 'recharts';
+import { PieChartWidget } from '../components/charts';
 
 const Savings = ({ onChange }) => {
   const [savings, setSavings] = useState([]);
@@ -216,24 +210,7 @@ const Savings = ({ onChange }) => {
 
           <div className="bg-gray-100 p-4 rounded">
             <h2 className="text-lg font-semibold mb-2">Savings Distribution</h2>
-            <ResponsiveContainer width="100%" height={250}>
-              <PieChart>
-                <Pie
-                  data={pieData}
-                  dataKey="value"
-                  nameKey="name"
-                  cx="50%"
-                  cy="50%"
-                  outerRadius={80}
-                  label
-                >
-                  {pieData.map((_, index) => (
-                    <Cell key={index} fill={COLORS[index % COLORS.length]} />
-                  ))}
-                </Pie>
-                <Tooltip />
-              </PieChart>
-            </ResponsiveContainer>
+            <PieChartWidget data={pieData} colors={COLORS} outerRadius={80} />
           </div>
         </>
       )}


### PR DESCRIPTION
## Summary
- create reusable chart components
- simplify Dashboard and Savings charts using widgets

## Testing
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_686503bddc80832ba0eab8b9444d1073