### PR TITLE
Wrap React app with AuthProvider

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -1,9 +1,10 @@
 // src/App.jsx
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import routes from './routes';
+import { useAuth } from './context/AuthContext';
 
 function App() {
-  const isAuthenticated = !!localStorage.getItem('token');
+  const { isAuthenticated } = useAuth();
 
   const renderRoutes = (routes) =>
     routes.map(({ path, element, protected: isProtected, children }) => {

--- a/client/src/main.jsx
+++ b/client/src/main.jsx
@@ -4,10 +4,13 @@ import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
 import { Toaster } from 'react-hot-toast';
+import { AuthProvider } from './context/AuthContext';
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <Toaster />
-    <App />
+    <AuthProvider>
+      <App />
+    </AuthProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- import `AuthProvider` and wrap `<App />` in `main.jsx`
- use `useAuth()` for auth status instead of localStorage in `App.jsx`

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6865085b5c40832ba5593ce6121f3003