### PR TITLE
Add loading spinner component

### DIFF
--- a/client/src/components/loading/Spinner.jsx
+++ b/client/src/components/loading/Spinner.jsx
@@ -1,0 +1,11 @@
+import React from 'react';
+
+const Spinner = ({ className = '' }) => (
+  <div className="flex justify-center" role="status" aria-label="Loading">
+    <div
+      className={`animate-spin h-8 w-8 border-4 border-blue-500 border-t-transparent rounded-full ${className}`.trim()}
+    />
+  </div>
+);
+
+export default Spinner;

--- a/client/src/components/loading/index.js
+++ b/client/src/components/loading/index.js
@@ -1,0 +1,1 @@
+export { default as Spinner } from './Spinner';

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -5,6 +5,7 @@ import {
   PieChartWidget,
   LineChartWidget,
 } from '../components/charts';
+import { Spinner } from '../components/loading';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7f7f', '#a1e3a1', '#ffd700', '#a1cfff'];
 
@@ -86,11 +87,14 @@ const Dashboard = () => {
     }, []);
 
   return (
-    <div className="max-w-5xl mx-auto bg-white p-6 rounded shadow">
+    <div
+      className="max-w-5xl mx-auto bg-white p-6 rounded shadow"
+      aria-busy={loading}
+    >
       <h1 className="text-3xl font-bold mb-6">Dashboard</h1>
 
       {loading ? (
-        <p>Loading...</p>
+        <Spinner />
       ) : (
         <>
           <div className="grid grid-cols-1 md:grid-cols-5 gap-4 mb-8 text-center">

--- a/client/src/pages/Expenses.jsx
+++ b/client/src/pages/Expenses.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import api from '../services/api';
 import { CategorySelect } from '../components/forms';
 import { toast } from 'react-hot-toast';
+import { Spinner } from '../components/loading';
 
 const Expenses = () => {
   const [expenses, setExpenses] = useState([]);
@@ -46,7 +47,10 @@ const Expenses = () => {
   });
 
   return (
-    <div className="max-w-2xl mx-auto bg-white p-6 rounded shadow">
+    <div
+      className="max-w-2xl mx-auto bg-white p-6 rounded shadow"
+      aria-busy={loading}
+    >
       <h1 className="text-2xl font-bold mb-4">Expenses</h1>
 
       <div className="flex flex-wrap gap-4 mb-6">
@@ -71,7 +75,7 @@ const Expenses = () => {
       </div>
 
       {loading ? (
-        <p className="text-gray-500">Loading expenses...</p>
+        <Spinner />
       ) : filteredExpenses.length === 0 ? (
         <p className="text-gray-500">No expenses recorded.</p>
       ) : (

--- a/client/src/pages/Income.jsx
+++ b/client/src/pages/Income.jsx
@@ -7,6 +7,7 @@ import {
   DateInput,
   CategorySelect,
 } from '../components/forms';
+import { Spinner } from '../components/loading';
 
 const Income = () => {
   const [incomes, setIncomes] = useState([]);
@@ -91,7 +92,10 @@ const Income = () => {
   }, []);
 
   return (
-    <div className="max-w-2xl mx-auto bg-white p-6 rounded shadow">
+    <div
+      className="max-w-2xl mx-auto bg-white p-6 rounded shadow"
+      aria-busy={loading}
+    >
       <h1 className="text-2xl font-bold mb-4">Income Tracker</h1>
 
       {/* Income Form */}
@@ -168,7 +172,7 @@ const Income = () => {
         </div>
 
         {loading ? (
-          <p className="text-gray-500">Loading incomes...</p>
+          <Spinner />
         ) : filtered.length === 0 ? (
           <p className="text-gray-500">No income added yet.</p>
         ) : (

--- a/client/src/pages/Transactions.jsx
+++ b/client/src/pages/Transactions.jsx
@@ -7,6 +7,7 @@ import {
   DateInput,
   CategorySelect,
 } from '../components/forms';
+import { Spinner } from '../components/loading';
 
 const Transactions = () => {
   const [formData, setFormData] = useState({
@@ -115,7 +116,10 @@ const Transactions = () => {
   }, []);
 
   return (
-    <div className="max-w-xl mx-auto bg-white p-6 rounded shadow">
+    <div
+      className="max-w-xl mx-auto bg-white p-6 rounded shadow"
+      aria-busy={loading}
+    >
       <h1 className="text-2xl font-bold mb-4">
         {isEditing ? 'Edit Transaction' : 'Add Transaction'}
       </h1>
@@ -215,7 +219,7 @@ const Transactions = () => {
         </div>
 
         {loading ? (
-          <p className="text-gray-500">Loading transactions...</p>
+          <Spinner />
         ) : transactions.length === 0 ? (
           <p className="text-gray-500">No transactions yet.</p>
         ) : (


### PR DESCRIPTION
## Summary
- add simple `Spinner` component
- use `Spinner` when loading in pages
- mark main page containers as busy with `aria-busy`

## Testing
- `npm test --silent` *(fails: `Codex couldn't run certain commands due to environment limitations. Consider configuring a setup script or internet access in your Codex environment to install dependencies.`)*

------
https://chatgpt.com/codex/tasks/task_e_68650917df80832bbad0eaca0c409689