### PR TITLE
Add 404 page and backend fallback

### DIFF
--- a/client/src/pages/NotFound.jsx
+++ b/client/src/pages/NotFound.jsx
@@ -1,0 +1,11 @@
+import { Link } from 'react-router-dom';
+
+const NotFound = () => (
+  <div className="text-center py-10">
+    <h1 className="text-4xl font-bold mb-4">Page Not Found</h1>
+    <p className="mb-6">Sorry, the page you're looking for does not exist.</p>
+    <Link to="/" className="text-blue-500 underline">Return Home</Link>
+  </div>
+);
+
+export default NotFound;

--- a/client/src/routes.jsx
+++ b/client/src/routes.jsx
@@ -13,6 +13,7 @@ import Insights from './pages/Insights';
 import Login from './pages/Login';
 import Register from './pages/Register';
 import Transactions from './pages/Transactions';
+import NotFound from './pages/NotFound';
 
 const routes = [
   {
@@ -40,6 +41,11 @@ const routes = [
   {
     path: '/register',
     element: <Register />,
+    protected: false,
+  },
+  {
+    path: '*',
+    element: <NotFound />,
     protected: false,
   },
 ];

--- a/server.js
+++ b/server.js
@@ -243,6 +243,11 @@ app.delete('/api/goals/:id', authMiddleware, async (req, res) => {
   }
 });
 
+// Catch-all for unknown API routes
+app.use((req, res) => {
+  res.status(404).json({ error: 'Endpoint not found' });
+});
+
 
 const PORT = process.env.PORT || 3000;
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));


### PR DESCRIPTION
## Summary
- add a `NotFound` page with a friendly message and link home
- wire the NotFound page in the client routes
- add a catch‑all middleware on the backend for unknown API routes

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` in client *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68650ba4b204832ba3962234b38169b4