### PR TITLE
Refactor categories and format utils

### DIFF
--- a/client/src/pages/Budget.jsx
+++ b/client/src/pages/Budget.jsx
@@ -6,8 +6,8 @@ import {
   DateInput,
   CategorySelect,
 } from '../components/forms';
+import { expenseCategories } from '../utils';
 
-const categories = ['Food', 'Rent', 'Utilities', 'Entertainment', 'Health', 'Transport', 'Other'];
 
 const Budget = () => {
   const [budgets, setBudgets] = useState([]);
@@ -80,7 +80,7 @@ const Budget = () => {
           name="category"
           value={formData.category}
           onChange={handleChange}
-          options={categories}
+          options={expenseCategories}
           required
         />
 

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -6,6 +6,7 @@ import {
   LineChartWidget,
 } from '../components/charts';
 import { Spinner } from '../components/loading';
+import { formatDate } from '../utils';
 
 const COLORS = ['#8884d8', '#82ca9d', '#ffc658', '#ff7f7f', '#a1e3a1', '#ffd700', '#a1cfff'];
 
@@ -165,7 +166,7 @@ const Dashboard = () => {
                   </span>
                 </div>
                 <p className="text-sm text-gray-700">
-                  {new Date(txn.date).toLocaleDateString()}
+                  {formatDate(txn.date)}
                 </p>
               </li>
             ))}

--- a/client/src/pages/Expenses.jsx
+++ b/client/src/pages/Expenses.jsx
@@ -3,22 +3,13 @@ import api from '../services/api';
 import { CategorySelect } from '../components/forms';
 import { toast } from 'react-hot-toast';
 import { Spinner } from '../components/loading';
+import { expenseCategories, formatDate } from '../utils';
 
 const Expenses = () => {
   const [expenses, setExpenses] = useState([]);
   const [filterMonth, setFilterMonth] = useState('');
   const [filterCategory, setFilterCategory] = useState('');
   const [loading, setLoading] = useState(true);
-
-  const categories = [
-    'Food',
-    'Rent',
-    'Utilities',
-    'Entertainment',
-    'Health',
-    'Transport',
-    'Other',
-  ];
 
   const fetchExpenses = async () => {
     setLoading(true);
@@ -70,7 +61,7 @@ const Expenses = () => {
           name="filterCategory"
           value={filterCategory}
           onChange={(e) => setFilterCategory(e.target.value)}
-          options={categories}
+          options={expenseCategories}
           placeholder="All"
         />
       </div>
@@ -88,7 +79,7 @@ const Expenses = () => {
                 <span className="text-red-600 font-semibold">-€{exp.amount}</span>
               </div>
               <div className="text-sm text-gray-600">
-                {new Date(exp.date).toLocaleDateString()} – {exp.description}
+                {formatDate(exp.date)} – {exp.description}
               </div>
             </li>
           ))}

--- a/client/src/pages/Goals.jsx
+++ b/client/src/pages/Goals.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import api from '../services/api';
 import { TextInput, NumberInput, DateInput } from '../components/forms';
+import { formatDate } from '../utils';
 
 const Goals = () => {
   const [formData, setFormData] = useState({
@@ -94,7 +95,7 @@ const Goals = () => {
                 <div className="text-gray-600 text-sm">
                   Target: €{goal.targetAmount}
                   {goal.deadline && (
-                    <> | Deadline: {new Date(goal.deadline).toLocaleDateString()}</>
+                    <> | Deadline: {formatDate(goal.deadline)}</>
                   )}
                 </div>
                 <button

--- a/client/src/pages/Income.jsx
+++ b/client/src/pages/Income.jsx
@@ -8,6 +8,7 @@ import {
   CategorySelect,
 } from '../components/forms';
 import { Spinner } from '../components/loading';
+import { incomeCategories, formatDate } from '../utils';
 
 const Income = () => {
   const [incomes, setIncomes] = useState([]);
@@ -23,7 +24,6 @@ const Income = () => {
   const [filterMonth, setFilterMonth] = useState('');
   const [filterCategory, setFilterCategory] = useState('');
 
-  const categories = ['Salary', 'Freelance', 'Business', 'Investment', 'Gift', 'Other'];
 
   const fetchIncomes = async () => {
     setLoading(true);
@@ -113,7 +113,7 @@ const Income = () => {
           name="category"
           value={formData.category}
           onChange={handleChange}
-          options={categories}
+          options={incomeCategories}
           required
         />
 
@@ -166,7 +166,7 @@ const Income = () => {
               className="border p-2 rounded"
             >
               <option value="">All</option>
-              {categories.map((cat) => (
+              {incomeCategories.map((cat) => (
                 <option key={cat} value={cat}>{cat}</option>
               ))}
             </select>
@@ -185,7 +185,7 @@ const Income = () => {
                   <div>
                     <div className="font-medium">{item.category}</div>
                     <div className="text-sm text-gray-600">
-                      {new Date(item.date).toLocaleDateString()} – {item.description || '—'}
+                      {formatDate(item.date)} – {item.description || '—'}
                     </div>
                   </div>
                   <div className="text-green-600 font-semibold">€{item.amount}</div>

--- a/client/src/pages/Investments.jsx
+++ b/client/src/pages/Investments.jsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 import api from '../services/api';
 import { TextInput, NumberInput, DateInput } from '../components/forms';
+import { formatDate } from '../utils';
 
 const Investments = () => {
   const [investments, setInvestments] = useState([]);
@@ -125,7 +126,7 @@ const Investments = () => {
               <span className="font-medium">{inv.name} ({inv.type})</span>
               <span className="text-green-600 font-semibold">€{inv.amount}</span>
             </div>
-            <div className="text-sm text-gray-600">{new Date(inv.date).toLocaleDateString()}</div>
+            <div className="text-sm text-gray-600">{formatDate(inv.date)}</div>
             <div className="flex gap-2 text-sm mt-2">
               <button onClick={() => handleEdit(inv)} className="text-blue-500">Edit</button>
               <button onClick={() => handleDelete(inv._id)} className="text-red-500">Delete</button>

--- a/client/src/pages/Savings.jsx
+++ b/client/src/pages/Savings.jsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import api from '../services/api';
 import { TextInput, NumberInput, DateInput } from '../components/forms';
 import { PieChartWidget } from '../components/charts';
+import { formatDate } from '../utils';
 
 const Savings = ({ onChange }) => {
   const [savings, setSavings] = useState([]);
@@ -182,7 +183,7 @@ const Savings = ({ onChange }) => {
                           .sort((a, b) => new Date(b.date) - new Date(a.date))
                           .map((c, idx) => (
                             <li key={idx}>
-                              €{c.amount} on {new Date(c.date).toLocaleDateString()}
+                              €{c.amount} on {formatDate(c.date)}
                             </li>
                           ))}
                       </ul>

--- a/client/src/pages/Transactions.jsx
+++ b/client/src/pages/Transactions.jsx
@@ -8,6 +8,7 @@ import {
   CategorySelect,
 } from '../components/forms';
 import { Spinner } from '../components/loading';
+import { incomeCategories, expenseCategories, formatDate } from '../utils';
 
 const Transactions = () => {
   const [formData, setFormData] = useState({
@@ -25,8 +26,6 @@ const Transactions = () => {
   const [filterCategory, setFilterCategory] = useState('');
   const [loading, setLoading] = useState(true);
 
-  const incomeCategories = ['Salary', 'Freelance', 'Bonus', 'Gift', 'Other'];
-  const expenseCategories = ['Food', 'Rent', 'Utilities', 'Entertainment', 'Health', 'Transport', 'Other'];
 
   const dynamicCategories = formData.type === 'income' ? incomeCategories : expenseCategories;
 
@@ -244,7 +243,7 @@ const Transactions = () => {
                     </span>
                   </div>
                   <div className="text-sm text-gray-600">
-                    {new Date(txn.date).toLocaleDateString()} - {txn.description}
+                    {formatDate(txn.date)} - {txn.description}
                   </div>
                   <button
                     onClick={() => handleEdit(txn)}

--- a/client/src/utils/categories.js
+++ b/client/src/utils/categories.js
@@ -1,0 +1,19 @@
+export const incomeCategories = [
+  'Salary',
+  'Freelance',
+  'Business',
+  'Investment',
+  'Bonus',
+  'Gift',
+  'Other',
+];
+
+export const expenseCategories = [
+  'Food',
+  'Rent',
+  'Utilities',
+  'Entertainment',
+  'Health',
+  'Transport',
+  'Other',
+];

--- a/client/src/utils/index.js
+++ b/client/src/utils/index.js
@@ -1,0 +1,2 @@
+export { default as formatDate } from './formatDate';
+export * from './categories';


### PR DESCRIPTION
## Summary
- centralize income and expense categories under `utils/categories.js`
- re-export helpers from `utils/index.js`
- replace local category arrays with shared imports
- apply shared `formatDate` when showing dates

## Testing
- `npm --workspaces=false --prefix client run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68650f72e7a8832ba534d4772fa9d82b