### PR TITLE
Fix Sidebar Toggle, Auth Redirect, and Logout Button

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -1,10 +1,15 @@
 // src/components/Layout.jsx
-import { Outlet, Link } from 'react-router-dom';
-import { useState } from 'react';
+import { Outlet, Link, useLocation } from 'react-router-dom';
+import { useEffect, useState } from 'react';
 import Navbar from './Navbar';
 
 const Layout = () => {
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const location = useLocation();
+
+  useEffect(() => {
+    setSidebarOpen(false);
+  }, [location.pathname]);
 
   return (
     <div className="flex min-h-screen">
@@ -22,6 +27,12 @@ const Layout = () => {
         <Link to="/goals">Goals</Link>
         <Link to="/insights">Insights</Link>
       </aside>
+      {sidebarOpen && (
+        <div
+          className="fixed inset-0 bg-black/50 md:hidden z-10"
+          onClick={() => setSidebarOpen(false)}
+        />
+      )}
 
       {/* Main Content */}
       <div className="flex flex-col flex-1">

--- a/client/src/components/Navbar.jsx
+++ b/client/src/components/Navbar.jsx
@@ -1,5 +1,15 @@
 // src/components/Navbar.jsx
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
 const Navbar = ({ toggleSidebar }) => {
+  const navigate = useNavigate();
+  const { logout } = useAuth();
+
+  const handleLogout = () => {
+    logout();
+    navigate('/login');
+  };
   return (
     <nav className="bg-gray-800 text-white p-4 flex justify-between items-center">
       <button
@@ -24,7 +34,12 @@ const Navbar = ({ toggleSidebar }) => {
       </button>
       <div className="flex-1">Welcome to SPFD</div>
       <div>
-        <button className="bg-gray-600 text-white border-none p-2">Logout</button>
+        <button
+          className="bg-gray-600 text-white border-none p-2"
+          onClick={handleLogout}
+        >
+          Logout
+        </button>
       </div>
     </nav>
   );

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -2,11 +2,12 @@
 import { useState } from 'react';
 import { toast } from 'react-hot-toast';
 import { useNavigate } from 'react-router-dom';
-import api from '../services/api';
+import { useAuth } from '../context/AuthContext';
 import { TextInput } from '../components/forms';
 
 const Login = () => {
   const navigate = useNavigate();
+  const { login } = useAuth();
 
   const [formData, setFormData] = useState({
     email: '',
@@ -22,9 +23,10 @@ const Login = () => {
     e.preventDefault();
 
     try {
-      const res = await api.post('/auth/login', formData);
-      localStorage.setItem('token', res.data.token); // ✅ Save token
-      navigate('/dashboard'); // ✅ Redirect
+      const res = await login(formData);
+      if (res.token) {
+        navigate('/dashboard');
+      }
     } catch (err) {
       console.error(err);
       toast.error(err.response?.data?.error || 'Login failed');


### PR DESCRIPTION
## Summary
- toggle sidebar on mobile and close on navigation or outside clicks
- update login page to use auth context for sign-in
- implement working logout button

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686628678310832b96c98c565d0c7cad