### PR TITLE
Add links between auth pages

### DIFF
--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -1,7 +1,7 @@
 // src/pages/Login.jsx
 import { useState } from 'react';
 import { toast } from 'react-hot-toast';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { TextInput } from '../components/forms';
 
@@ -69,6 +69,12 @@ const Login = () => {
           Login
         </button>
       </form>
+      <p className="mt-4 text-center text-sm">
+        Don't have an account?{' '}
+        <Link to="/register" className="text-blue-600 underline">
+          Register here
+        </Link>
+      </p>
     </div>
   );
 };

--- a/client/src/pages/Register.jsx
+++ b/client/src/pages/Register.jsx
@@ -1,6 +1,6 @@
 // src/pages/Register.jsx
 import { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, Link } from 'react-router-dom';
 import axios from '../services/api'; // Make sure this points to your axios setup
 import { TextInput } from '../components/forms';
 import { toast } from 'react-hot-toast';
@@ -55,6 +55,12 @@ const Register = () => {
           Register
         </button>
       </form>
+      <p className="mt-4 text-center text-sm">
+        Already have an account?{' '}
+        <Link to="/login" className="text-blue-600 underline">
+          Log in here
+        </Link>
+      </p>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `Link` imports and navigation prompts
- connect Login page to Register page and vice versa

## Testing
- `npm test` (fails: Missing script)
- `cd client && npm test` (fails: Missing script)

------
https://chatgpt.com/codex/tasks/task_e_68662af028c4832b844685cdb7f900bd