### PR TITLE
Improve transactions UX

### DIFF
--- a/client/src/components/Layout.jsx
+++ b/client/src/components/Layout.jsx
@@ -19,6 +19,7 @@ const Layout = () => {
       >
         <h2 className="mb-2 font-semibold">SPFD</h2>
         <Link to="/">Dashboard</Link>
+        <Link to="/transactions">Transactions</Link>
         <Link to="/income">Income</Link>
         <Link to="/expenses">Expenses</Link>
         <Link to="/budget">Budget</Link>
@@ -39,6 +40,13 @@ const Layout = () => {
         <Navbar toggleSidebar={() => setSidebarOpen((o) => !o)} />
         <main className="p-6 overflow-y-auto flex-1">
           <Outlet />
+          <Link
+            to="/transactions"
+            className="fixed bottom-6 right-6 bg-blue-600 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg hover:bg-blue-700"
+            aria-label="Add transaction"
+          >
+            +
+          </Link>
         </main>
       </div>
     </div>

--- a/client/src/pages/Transactions.jsx
+++ b/client/src/pages/Transactions.jsx
@@ -24,6 +24,7 @@ const Transactions = () => {
   const [editId, setEditId] = useState(null);
   const [filterMonth, setFilterMonth] = useState('');
   const [filterCategory, setFilterCategory] = useState('');
+  const [filterType, setFilterType] = useState('');
   const [loading, setLoading] = useState(true);
 
 
@@ -119,9 +120,11 @@ const Transactions = () => {
       className="max-w-xl mx-auto bg-white p-6 rounded shadow"
       aria-busy={loading}
     >
-      <h1 className="text-2xl font-bold mb-4">
+      <h1 className="text-3xl font-bold mb-6">Track Income &amp; Expenses</h1>
+
+      <h2 className="text-2xl font-bold mb-4">
         {isEditing ? 'Edit Transaction' : 'Add Transaction'}
-      </h1>
+      </h2>
 
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
@@ -218,6 +221,20 @@ const Transactions = () => {
               ))}
             </select>
           </div>
+
+          <div>
+            <label htmlFor="txnFilterType" className="block text-sm font-medium mb-1">Filter by Type</label>
+            <select
+              id="txnFilterType"
+              value={filterType}
+              onChange={(e) => setFilterType(e.target.value)}
+              className="border p-2 rounded"
+            >
+              <option value="">All</option>
+              <option value="income">Income</option>
+              <option value="expense">Expense</option>
+            </select>
+          </div>
         </div>
 
         {loading ? (
@@ -231,7 +248,8 @@ const Transactions = () => {
                 const txnMonth = txn.date?.slice(0, 7);
                 return (
                   (filterMonth === '' || txnMonth === filterMonth) &&
-                  (filterCategory === '' || txn.category === filterCategory)
+                  (filterCategory === '' || txn.category === filterCategory) &&
+                  (filterType === '' || txn.type === filterType)
                 );
               })
               .map((txn) => (


### PR DESCRIPTION
## Summary
- add Transactions link to sidebar
- show a floating `+` button to add transactions
- improve Transactions page with new title and filter by type

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686640b311e4832bae77ce683616a26a