### PR TITLE
Add transaction filtering by category and amount

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ A full‑stack application to track income, expenses, savings and investments. T
 - `POST /api/auth/login` – authenticate user (sets JWT cookie)
 
 ### Transactions
-- `GET /api/transactions` – list all transactions
+- `GET /api/transactions` – list all transactions (query: `type`, `month`, `category`, `min`, `max`)
 - `POST /api/transactions` – create a transaction
 - `PUT /api/transactions/:id` – update transaction
 - `DELETE /api/transactions/:id` – delete transaction

--- a/routes/transactionRoutes.js
+++ b/routes/transactionRoutes.js
@@ -11,11 +11,15 @@ router.use(authMiddleware);
 // ✅ GET all transactions for the logged-in user
 router.get('/', async (req, res) => {
   try {
-    const { type, month } = req.query;
+    const { type, month, category, min, max } = req.query;
     const filter = { userId: req.user.id };
 
     if (type) {
       filter.type = type.toLowerCase();
+    }
+
+    if (category) {
+      filter.category = category;
     }
 
     if (month) {
@@ -25,6 +29,16 @@ router.get('/', async (req, res) => {
       const start = new Date(year, monthIdx, 1);
       const end = new Date(year, monthIdx + 1, 1);
       filter.date = { $gte: start, $lt: end };
+    }
+
+    if (min || max) {
+      filter.amount = {};
+      if (min) {
+        filter.amount.$gte = parseFloat(min);
+      }
+      if (max) {
+        filter.amount.$lte = parseFloat(max);
+      }
     }
 
     const transactions = await Transaction.find(filter).sort({ date: -1 });


### PR DESCRIPTION
## Summary
- support filtering transactions by category and amount range
- document new query parameters in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686652b0c914832b8baf4201bd794c6f