### PR TITLE
Add chart placeholder for empty pie charts

### DIFF
--- a/client/src/components/charts/ChartPlaceholder.jsx
+++ b/client/src/components/charts/ChartPlaceholder.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+const ChartPlaceholder = ({ height = 160 }) => (
+  <div
+    className="flex items-center justify-center bg-gray-200 rounded"
+    style={{ height }}
+    aria-hidden="true"
+  >
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className="w-8 h-8 text-gray-400"
+    >
+      <path d="M3 3h18v18H3z" fill="none" />
+      <path
+        d="M5 13h3v6H5zm5-4h3v10h-3zm5-3h3v13h-3z"
+        className="text-gray-400"
+        fill="currentColor"
+      />
+    </svg>
+  </div>
+);
+
+export default ChartPlaceholder;

--- a/client/src/components/charts/index.js
+++ b/client/src/components/charts/index.js
@@ -1,3 +1,4 @@
 export { default as BarChartWidget } from './BarChartWidget.jsx';
 export { default as PieChartWidget } from './PieChartWidget.jsx';
 export { default as LineChartWidget } from './LineChartWidget.jsx';
+export { default as ChartPlaceholder } from './ChartPlaceholder.jsx';

--- a/client/src/pages/Income.jsx
+++ b/client/src/pages/Income.jsx
@@ -2,7 +2,7 @@ import { useState, useEffect } from 'react';
 import api from '../services/api';
 import { toast } from 'react-hot-toast';
 import { CategorySelect, NumberInput } from '../components/forms';
-import { PieChartWidget, LineChartWidget } from '../components/charts';
+import { PieChartWidget, LineChartWidget, ChartPlaceholder } from '../components/charts';
 import { Spinner } from '../components/loading';
 import { incomeCategories, formatDate } from '../utils';
 
@@ -186,7 +186,7 @@ const Income = () => {
         <div className="bg-gray-100 p-4 rounded">
           <h2 className="text-lg font-semibold mb-2">Income by Category</h2>
           {pieData.length === 0 ? (
-            <p className="text-gray-700">No data</p>
+            <ChartPlaceholder height={200} />
           ) : (
             <PieChartWidget data={pieData} colors={COLORS} outerRadius={80} />
           )}


### PR DESCRIPTION
## Summary
- add `ChartPlaceholder` component with simple SVG
- export placeholder from charts index
- show placeholder when there is no pie chart data on the Income page

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866548e0ae4832bbaf0569c8241f9d8