### PR TITLE
Adjust recent entries slice bounds

### DIFF
--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -49,9 +49,10 @@ const Dashboard = () => {
   const netBalance = incomeTotal - expenseTotal;
   const availableBalance = netBalance - savingsTotal;
 
+  const latestCount = Math.min(Math.max(transactions.length, 5), 10);
   const latestFive = [...transactions]
     .sort((a, b) => new Date(b.date) - new Date(a.date))
-    .slice(0, 5);
+    .slice(0, latestCount);
 
   const expenseByCategory = expenses.reduce((acc, txn) => {
     const category = txn.category || 'Other';

--- a/client/src/pages/Income.jsx
+++ b/client/src/pages/Income.jsx
@@ -149,9 +149,10 @@ const Income = () => {
   });
   const pieData = Object.entries(byCategory).map(([name, value]) => ({ name, value }));
 
+  const entriesToShow = Math.min(Math.max(filtered.length, 5), 10);
   const latestEntries = [...filtered]
     .sort((a, b) => new Date(b.date) - new Date(a.date))
-    .slice(0, 10);
+    .slice(0, entriesToShow);
 
   return (
     <div className="max-w-6xl mx-auto p-4" aria-busy={loading}>


### PR DESCRIPTION
## Summary
- update recent entries logic to enforce 5-10 row display
- same for recent transactions on the dashboard

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68665677aa2c832b9d31cf1a37a6d55d