### PR TITLE
Add recurring transaction fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,13 @@ A full‑stack application to track income, expenses, savings and investments. T
 - `PUT /api/transactions/:id` – update transaction
 - `DELETE /api/transactions/:id` – delete transaction
 
+`POST` and `PUT` requests accept these fields:
+
+- `recurring` (boolean) – set to `true` for repeating expenses or income
+- `frequency` (string) – one of `monthly`, `quarterly`, `yearly` (defaults to `monthly`)
+
+Recurring entries are stored for future use. Automation not yet implemented.
+
 ### Income & Expenses
 - `GET /api/income` / `POST /api/income`
 - `GET /api/expenses` / `POST /api/expenses`

--- a/client/src/pages/Transactions.jsx
+++ b/client/src/pages/Transactions.jsx
@@ -27,6 +27,8 @@ const Transactions = () => {
     category: '',
     date: '',
     description: '',
+    recurring: false,
+    frequency: 'monthly',
   });
 
   const [transactions, setTransactions] = useState([]);
@@ -35,6 +37,7 @@ const Transactions = () => {
   const [filterMonth, setFilterMonth] = useState('');
   const [filterCategory, setFilterCategory] = useState('');
   const [filterType, setFilterType] = useState('');
+  const [filterRecurring, setFilterRecurring] = useState('');
   const [loading, setLoading] = useState(true);
 
 
@@ -48,9 +51,11 @@ const Transactions = () => {
     formData.date;
 
   const handleChange = (e) => {
+    const value =
+      e.target.type === 'checkbox' ? e.target.checked : e.target.value;
     setFormData({
       ...formData,
-      [e.target.name]: e.target.value,
+      [e.target.name]: value,
     });
   };
 
@@ -86,6 +91,8 @@ const Transactions = () => {
       category: txn.category,
       date: txn.date.slice(0, 10),
       description: txn.description,
+      recurring: txn.recurring || false,
+      frequency: txn.frequency || 'monthly',
     });
     setIsEditing(true);
     setEditId(txn._id);
@@ -98,6 +105,8 @@ const Transactions = () => {
       category: '',
       date: '',
       description: '',
+      recurring: false,
+      frequency: 'monthly',
     });
     setIsEditing(false);
     setEditId(null);
@@ -132,6 +141,7 @@ const Transactions = () => {
     setFilterMonth('');
     setFilterCategory('');
     setFilterType('');
+    setFilterRecurring('');
   };
 
   useEffect(() => {
@@ -199,6 +209,36 @@ const Transactions = () => {
             placeholder="e.g. Rent, Groceries"
           />
 
+          <div>
+            <div className="flex items-center gap-4">
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  name="recurring"
+                  checked={formData.recurring}
+                  onChange={handleChange}
+                />
+                Mark as Recurring
+              </label>
+              {formData.recurring && (
+                <select
+                  name="frequency"
+                  value={formData.frequency}
+                  onChange={handleChange}
+                  className="border p-2 rounded"
+                >
+                  <option value="monthly">Monthly</option>
+                  <option value="quarterly">Quarterly</option>
+                  <option value="yearly">Yearly</option>
+                </select>
+              )}
+            </div>
+            <p className="text-xs text-gray-600 mt-1">
+              Recurring expenses repeat regularly. Future versions will automate
+              this.
+            </p>
+          </div>
+
           <div className="flex gap-3">
             <button
               type="submit"
@@ -264,6 +304,20 @@ const Transactions = () => {
             </select>
           </div>
 
+          <div>
+            <label htmlFor="txnFilterRecurring" className="block text-sm font-medium mb-1">Filter by Recurring</label>
+            <select
+              id="txnFilterRecurring"
+              value={filterRecurring}
+              onChange={(e) => setFilterRecurring(e.target.value)}
+              className="border p-2 rounded"
+            >
+              <option value="">All</option>
+              <option value="one-time">One-Time</option>
+              <option value="recurring">Recurring</option>
+            </select>
+          </div>
+
           <button
             type="button"
             onClick={clearFilters}
@@ -282,10 +336,15 @@ const Transactions = () => {
             {transactions
               .filter((txn) => {
                 const txnMonth = txn.date?.slice(0, 7);
+                const recMatch =
+                  filterRecurring === '' ||
+                  (filterRecurring === 'recurring' && txn.recurring) ||
+                  (filterRecurring === 'one-time' && !txn.recurring);
                 return (
                   (filterMonth === '' || txnMonth === filterMonth) &&
                   (filterCategory === '' || txn.category === filterCategory) &&
-                  (filterType === '' || txn.type === filterType)
+                  (filterType === '' || txn.type === filterType) &&
+                  recMatch
                 );
               })
               .map((txn) => {
@@ -310,10 +369,15 @@ const Transactions = () => {
                         €{txn.amount}
                       </span>
                     </div>
-                    <div className="text-sm text-gray-600">
-                      {formatLongDate(txn.date)} -{' '}
-                      <span title={txn.description}>{truncated}</span>
-                    </div>
+                  <div className="text-sm text-gray-600">
+                    {formatLongDate(txn.date)} -{' '}
+                    <span title={txn.description}>{truncated}</span>
+                    {txn.recurring && (
+                      <span className="ml-2 px-2 py-0.5 text-xs bg-purple-100 text-purple-700 rounded-full">
+                        🔁 Recurring
+                      </span>
+                    )}
+                  </div>
                     <button
                       onClick={() => handleEdit(txn)}
                       title="Edit"

--- a/models/Transaction.js
+++ b/models/Transaction.js
@@ -12,6 +12,11 @@ const TransactionSchema = new mongoose.Schema({
   category: { type: String },
   date: { type: Date, default: Date.now },
   recurring: { type: Boolean, default: false },
+  frequency: {
+    type: String,
+    enum: ['monthly', 'quarterly', 'yearly'],
+    default: 'monthly',
+  },
   description: { type: String }, // Optional but useful for UI
 });
 


### PR DESCRIPTION
## Summary
- support recurring transactions with new `frequency` field
- document recurring options in README
- show recurring form controls and badge in transaction UI
- allow filtering by recurring flag

## Testing
- `node -v`
- `npm --version`

------
https://chatgpt.com/codex/tasks/task_e_68667d245050832b966e024a12956694