### PR TITLE
Add inline transaction editing component

### DIFF
--- a/client/src/components/TransactionItem.jsx
+++ b/client/src/components/TransactionItem.jsx
@@ -1,0 +1,140 @@
+import { useState } from 'react';
+import PropTypes from 'prop-types';
+import { NumberInput, CategorySelect, DateInput, TextInput } from './forms';
+import { incomeCategories, expenseCategories, formatDate } from '../utils';
+import api from '../services/api';
+import { toast } from 'react-hot-toast';
+
+const TransactionItem = ({ transaction, onDelete, onUpdate }) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [form, setForm] = useState({
+    amount: transaction.amount,
+    category: transaction.category,
+    date: formatDate(transaction.date),
+    description: transaction.description || '',
+  });
+
+  // TODO: Inline Edit Logic
+
+  const handleChange = (e) => {
+    setForm({ ...form, [e.target.name]: e.target.value });
+  };
+
+  const handleSave = async () => {
+    try {
+      await api.patch(`/transactions/${transaction._id}`, {
+        amount: Number(form.amount),
+        category: form.category,
+        date: form.date,
+        description: form.description,
+      });
+      toast.success('Transaction updated');
+      setIsEditing(false);
+      if (onUpdate) onUpdate();
+    } catch (err) {
+      console.error('Update error:', err.response?.data || err.message);
+      toast.error(err.response?.data?.message || err.message);
+    }
+  };
+
+  const categories =
+    transaction.type === 'income' ? incomeCategories : expenseCategories;
+
+  const truncated =
+    transaction.description && transaction.description.length > 30
+      ? `${transaction.description.slice(0, 30)}...`
+      : transaction.description;
+
+  const formattedDate = new Date(transaction.date).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'long',
+    day: 'numeric',
+  });
+
+  return (
+    <li className="border rounded-lg p-4 shadow-sm relative">
+      {isEditing ? (
+        <div className="space-y-2">
+          <NumberInput name="amount" value={form.amount} onChange={handleChange} />
+          <CategorySelect
+            name="category"
+            value={form.category}
+            onChange={handleChange}
+            options={categories}
+          />
+          <DateInput name="date" value={form.date} onChange={handleChange} />
+          <TextInput
+            name="description"
+            value={form.description}
+            onChange={handleChange}
+          />
+          <div className="flex gap-2">
+            <button
+              onClick={handleSave}
+              className="text-green-600 hover:text-green-800 text-sm"
+            >
+              Save
+            </button>
+            <button
+              onClick={() => {
+                setForm({
+                  amount: transaction.amount,
+                  category: transaction.category,
+                  date: formatDate(transaction.date),
+                  description: transaction.description || '',
+                });
+                setIsEditing(false);
+              }}
+              className="text-gray-500 hover:text-gray-700 text-sm"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="flex justify-between">
+            <span className="font-medium">
+              {transaction.category} ({transaction.type})
+            </span>
+            <span
+              className={
+                transaction.type === 'income' ? 'text-green-600' : 'text-red-600'
+              }
+            >
+              €{transaction.amount}
+            </span>
+          </div>
+          <div className="text-sm text-gray-600">
+            {formattedDate} - <span title={transaction.description}>{truncated}</span>
+            {transaction.recurring && (
+              <span className="ml-2 px-2 py-0.5 text-xs bg-purple-100 text-purple-700 rounded-full">
+                🔁 Recurring
+              </span>
+            )}
+          </div>
+          <button
+            onClick={() => setIsEditing(true)}
+            className="absolute top-2 right-16 text-blue-500 hover:text-blue-700 text-sm"
+          >
+            Edit
+          </button>
+          <button
+            onClick={() => onDelete(transaction._id)}
+            className="absolute top-2 right-2 text-red-500 hover:text-red-700 text-sm"
+          >
+            Delete
+          </button>
+        </>
+      )}
+    </li>
+  );
+};
+
+TransactionItem.propTypes = {
+  transaction: PropTypes.object.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onUpdate: PropTypes.func,
+};
+
+export default TransactionItem;

--- a/client/src/pages/Transactions.jsx
+++ b/client/src/pages/Transactions.jsx
@@ -8,17 +8,8 @@ import {
   CategorySelect,
 } from '../components/forms';
 import { Spinner } from '../components/loading';
-import { incomeCategories, expenseCategories, formatDate } from '../utils';
-
-const formatLongDate = (input) => {
-  const d = new Date(input);
-  if (Number.isNaN(d.getTime())) return '';
-  return d.toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-};
+import { incomeCategories, expenseCategories } from '../utils';
+import TransactionItem from '../components/TransactionItem';
 
 const Transactions = () => {
   const [formData, setFormData] = useState({
@@ -347,54 +338,14 @@ const Transactions = () => {
                   recMatch
                 );
               })
-              .map((txn) => {
-                const truncated =
-                  txn.description && txn.description.length > 30
-                    ? `${txn.description.slice(0, 30)}...`
-                    : txn.description;
-                return (
-                  <li
-                    key={txn._id}
-                    className="border rounded-lg p-4 shadow-sm relative"
-                  >
-                    <div className="flex justify-between">
-                      <span className="font-medium">
-                        {txn.category} ({txn.type})
-                      </span>
-                      <span
-                        className={
-                          txn.type === 'income' ? 'text-green-600' : 'text-red-600'
-                        }
-                      >
-                        €{txn.amount}
-                      </span>
-                    </div>
-                  <div className="text-sm text-gray-600">
-                    {formatLongDate(txn.date)} -{' '}
-                    <span title={txn.description}>{truncated}</span>
-                    {txn.recurring && (
-                      <span className="ml-2 px-2 py-0.5 text-xs bg-purple-100 text-purple-700 rounded-full">
-                        🔁 Recurring
-                      </span>
-                    )}
-                  </div>
-                    <button
-                      onClick={() => handleEdit(txn)}
-                      title="Edit"
-                      className="absolute top-2 right-16 text-blue-500 hover:text-blue-700 text-sm"
-                    >
-                      🖉
-                    </button>
-                    <button
-                      onClick={() => handleDelete(txn._id)}
-                      title="Delete"
-                      className="absolute top-2 right-2 text-red-500 hover:text-red-700 text-sm"
-                    >
-                      🗑
-                    </button>
-                  </li>
-                );
-              })}
+              .map((txn) => (
+                <TransactionItem
+                  key={txn._id}
+                  transaction={txn}
+                  onDelete={handleDelete}
+                  onUpdate={fetchTransactions}
+                />
+              ))}
           </ul>
         )}
       </div>


### PR DESCRIPTION
## Summary
- create `TransactionItem` component with inline editing support
- update `Transactions` page to render `TransactionItem`
- use PATCH for transaction updates

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686683455314832bad9abd594863720f