### PR TITLE
Handle paused recurring transactions

### DIFF
--- a/middleware/validation.js
+++ b/middleware/validation.js
@@ -7,6 +7,12 @@ export const validateTransaction = (req, res, next) => {
   if (isNaN(amt)) {
     return res.status(400).json({ error: 'Invalid or missing amount' });
   }
+  if (
+    req.body.recurringPaused !== undefined &&
+    typeof req.body.recurringPaused !== 'boolean'
+  ) {
+    return res.status(400).json({ error: 'Invalid recurringPaused' });
+  }
   next();
 };
 
@@ -16,6 +22,12 @@ export const validateTransactionUpdate = (req, res, next) => {
   }
   if (req.body.amount !== undefined && isNaN(Number(req.body.amount))) {
     return res.status(400).json({ error: 'Invalid amount' });
+  }
+  if (
+    req.body.recurringPaused !== undefined &&
+    typeof req.body.recurringPaused !== 'boolean'
+  ) {
+    return res.status(400).json({ error: 'Invalid recurringPaused' });
   }
   next();
 };

--- a/models/Transaction.js
+++ b/models/Transaction.js
@@ -12,6 +12,7 @@ const TransactionSchema = new mongoose.Schema({
   category: { type: String },
   date: { type: Date, default: Date.now },
   recurring: { type: Boolean, default: false },
+  recurringPaused: { type: Boolean, default: false },
   frequency: {
     type: String,
     enum: ['monthly', 'quarterly', 'yearly'],

--- a/utils/recurring.js
+++ b/utils/recurring.js
@@ -24,6 +24,9 @@ export async function generateRecurringTransactions(userId) {
   const updates = [];
 
   for (const tx of recurringTxns) {
+    if (tx.recurringPaused) {
+      continue;
+    }
     let lastDate = tx.lastGenerated || tx.date;
     const increment =
       tx.frequency === 'monthly' ? 1 : tx.frequency === 'quarterly' ? 3 : 12;


### PR DESCRIPTION
## Summary
- allow transactions to be paused
- skip paused transactions when generating recurring entries
- validate `recurringPaused` flag on creation or update

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867a02d3b08832bbfd214f2fdea91a0