### PR TITLE
Improve recurring transaction UX

### DIFF
--- a/client/src/components/TransactionItem.jsx
+++ b/client/src/components/TransactionItem.jsx
@@ -12,12 +12,14 @@ const TransactionItem = ({ transaction, onDelete, onUpdate }) => {
     category: transaction.category,
     date: formatDate(transaction.date),
     description: transaction.description || '',
+    recurring: transaction.recurring || false,
+    frequency: transaction.frequency || 'monthly',
   });
 
-  // TODO: Inline Edit Logic
 
   const handleChange = (e) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
+    const value = e.target.type === 'checkbox' ? e.target.checked : e.target.value;
+    setForm({ ...form, [e.target.name]: value });
   };
 
   const handleSave = async () => {
@@ -27,6 +29,8 @@ const TransactionItem = ({ transaction, onDelete, onUpdate }) => {
         category: form.category,
         date: form.date,
         description: form.description,
+        recurring: form.recurring,
+        frequency: form.frequency,
       });
       toast.success('Transaction updated');
       setIsEditing(false);
@@ -83,6 +87,28 @@ const TransactionItem = ({ transaction, onDelete, onUpdate }) => {
             value={form.description}
             onChange={handleChange}
           />
+          <div className="flex items-center gap-4">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                name="recurring"
+                checked={form.recurring}
+                onChange={handleChange}
+              />
+              Recurring
+            </label>
+            <select
+              name="frequency"
+              value={form.frequency}
+              onChange={handleChange}
+              disabled={!form.recurring}
+              className="border p-2 rounded"
+            >
+              <option value="monthly">Monthly</option>
+              <option value="quarterly">Quarterly</option>
+              <option value="yearly">Yearly</option>
+            </select>
+          </div>
           <div className="flex gap-2">
             <button
               onClick={handleSave}
@@ -97,6 +123,8 @@ const TransactionItem = ({ transaction, onDelete, onUpdate }) => {
                   category: transaction.category,
                   date: formatDate(transaction.date),
                   description: transaction.description || '',
+                  recurring: transaction.recurring || false,
+                  frequency: transaction.frequency || 'monthly',
                 });
                 setIsEditing(false);
               }}
@@ -123,12 +151,12 @@ const TransactionItem = ({ transaction, onDelete, onUpdate }) => {
           <div className="text-sm text-gray-600">
             {formattedDate} - <span title={transaction.description}>{truncated}</span>
             {transaction.recurring && (
-              <span className="ml-2 px-2 py-0.5 text-xs bg-purple-100 text-purple-700 rounded-full">
+              <span className="ml-2 px-2 py-1 text-xs bg-blue-100 text-blue-700 rounded">
                 ♻️ Recurring
               </span>
             )}
             {transaction.recurringPaused && (
-              <span className="ml-2 px-2 py-0.5 text-xs bg-yellow-100 text-yellow-700 rounded-full">
+              <span className="ml-2 px-2 py-1 text-xs bg-gray-100 text-gray-600 rounded">
                 ⏸ Paused
               </span>
             )}
@@ -136,15 +164,20 @@ const TransactionItem = ({ transaction, onDelete, onUpdate }) => {
           {transaction.lastGenerated && (
             <div className="text-xs text-gray-500 mt-1">
               Last generated:{' '}
-              {new Date(transaction.lastGenerated).toLocaleDateString()}
+              {new Date(transaction.lastGenerated).toLocaleDateString(undefined, {
+                year: 'numeric',
+                month: 'long',
+                day: 'numeric',
+              })}
             </div>
           )}
           {transaction.recurring && (
             <button
               onClick={handleTogglePause}
-              className="absolute top-2 right-32 text-yellow-500 hover:text-yellow-700 text-sm"
+              title="Pause/Resume this recurring transaction"
+              className="absolute top-2 right-32 text-gray-500 hover:text-gray-700 text-sm"
             >
-              {transaction.recurringPaused ? 'Resume' : 'Pause'}
+              {transaction.recurringPaused ? '▶️' : '⏸'}
             </button>
           )}
           <button

--- a/client/src/pages/Transactions.jsx
+++ b/client/src/pages/Transactions.jsx
@@ -152,10 +152,10 @@ const Transactions = () => {
     setFilterRecurring('');
   };
 
-  const applyRecurringExpenses = async () => {
+  const triggerRecurringNow = async () => {
     try {
       const res = await api.post('/transactions/recurring');
-      toast.success(`Applied ${res.data.generated} recurring transactions`);
+      toast.success(`Generated ${res.data.generated} transactions`);
       fetchTransactions();
     } catch (error) {
       console.error(
@@ -192,13 +192,6 @@ const Transactions = () => {
     <div className="max-w-4xl mx-auto p-4 space-y-8" aria-busy={loading}>
       <div className="flex items-center justify-between mb-6">
         <h1 className="text-3xl font-bold">Track Income &amp; Expenses</h1>
-        <button
-          type="button"
-          onClick={applyRecurringExpenses}
-          className="bg-purple-500 text-white px-3 py-2 rounded hover:bg-purple-600"
-        >
-          Apply Recurring Expenses
-        </button>
       </div>
 
       <div className="bg-white p-6 rounded-xl shadow-md">
@@ -267,18 +260,17 @@ const Transactions = () => {
                 />
                 Mark as Recurring
               </label>
-              {formData.recurring && (
-                <select
-                  name="frequency"
-                  value={formData.frequency}
-                  onChange={handleChange}
-                  className="border p-2 rounded"
-                >
-                  <option value="monthly">Monthly</option>
-                  <option value="quarterly">Quarterly</option>
-                  <option value="yearly">Yearly</option>
-                </select>
-              )}
+              <select
+                name="frequency"
+                value={formData.frequency}
+                onChange={handleChange}
+                disabled={!formData.recurring}
+                className="border p-2 rounded"
+              >
+                <option value="monthly">Monthly</option>
+                <option value="quarterly">Quarterly</option>
+                <option value="yearly">Yearly</option>
+              </select>
             </div>
             <p className="text-xs text-gray-600 mt-1">
               Recurring expenses repeat regularly. Future versions will automate
@@ -399,6 +391,17 @@ const Transactions = () => {
           </ul>
         )}
       </div>
+      {import.meta.env.DEV && (
+        <div className="text-right mt-4">
+          <button
+            type="button"
+            onClick={triggerRecurringNow}
+            className="bg-purple-500 text-white px-3 py-2 rounded hover:bg-purple-600"
+          >
+            Trigger Recurring Now
+          </button>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- enhance transaction editing to include recurring fields
- add pause/resume toggle and recurring badges to `TransactionItem`
- move recurring trigger button to dev-only section in Transactions page
- support disabling frequency field when not recurring

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix client test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6867a9584fc4832b9a684c8255398084